### PR TITLE
Add setApiToken to pinterestNodeClient class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -198,6 +198,8 @@ declare class pinterestNodeClient {
 
   setUserToken(userToken: string): void;
 
+  setApiToken(clientId: string, clientSecret: string): void;
+
   ads: Ads;
   pins: Pins;
   bulk: Bulk;


### PR DESCRIPTION
This PR aims to add the missing TypeScript types for the setApiToken on the pinterestNodeClient class.